### PR TITLE
Make `write_array` require less specialization

### DIFF
--- a/src/SimpleHDF5.jl
+++ b/src/SimpleHDF5.jl
@@ -129,7 +129,7 @@ function write_array(file_id::API.hid_t, dataset_name::String, @nospecialize(dat
 
     reverse!(dims)  # HDF5 uses C ordering (last dimension varies fastest)
     dataspace_id = API.h5s_create_simple(rank, dims, C_NULL)
-    datatype_id = _get_h5_datatype(eltype(data))
+    datatype_id = _get_h5_datatype(eltype(data)::Type)
 
     # Create dataset
     dataset_id = API.h5d_create(

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -924,7 +924,7 @@ end
 
 See `libhdf5` documentation for [`H5Dwrite`](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_d.html#ga98f44998b67587662af8b0d8a0a75906).
 """
-function h5d_write(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
+function h5d_write(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, @nospecialize(buf::Array))
     lock(liblock)
     var"#status#" = try
             ccall((:H5Dwrite, libhdf5), herr_t, (hid_t, hid_t, hid_t, hid_t, hid_t, Ptr{Cvoid}), dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)

--- a/test/test_type_stability.jl
+++ b/test/test_type_stability.jl
@@ -35,6 +35,9 @@ using JET
         JET.@test_opt write_array(file_id, "float_array", float_array)
         JET.@test_opt write_array(file_id, "bool_array", bool_array)
 
+        # write_array should be optimized even with an unknown array type
+        JET.test_opt(write_array, (typeof(file_id), String, Array))
+
         # Actually write the arrays for subsequent tests
         write_array(file_id, "int_array", int_array)
         write_array(file_id, "float_array", float_array)


### PR DESCRIPTION
This massages the implementation of `write_array` to be fully-inferred even for Array's of unknown type / dimensions.

There's very little we're doing here other than looking up our dims and passing a pointer to C, so the main trick is to avoid over-specialization in other parts of Base (e.g. we have no way to type-stably convert `NTuple{N,Int64}` into `Vector{Int}` right now)