### PR TITLE
Use `ArgumentError` for high-level API errors

### DIFF
--- a/src/SimpleHDF5.jl
+++ b/src/SimpleHDF5.jl
@@ -229,7 +229,7 @@ function read_array(file_id::API.hid_t, dataset_name::String, ::Type{Array{T,N}}
     dims = Vector{API.hsize_t}(undef, rank)
     API.h5s_get_simple_extent_dims(dataspace_id, dims, C_NULL)
     if length(dims) != N
-        throw(API.H5Error("Dimension mismatch: expected $N-dimensional array, got $(length(dims))-dimensional array"))
+        throw(ArgumentError("Dimension mismatch: expected $N-dimensional array, got $(length(dims))-dimensional array"))
     end
     data = Array{T}(undef, reverse(ntuple(i -> dims[i], N)))
 
@@ -242,7 +242,7 @@ function read_array(file_id::API.hid_t, dataset_name::String, ::Type{Array{T,N}}
         API.h5t_close(stored_datatype_id)
         API.h5s_close(dataspace_id)
         API.h5d_close(dataset_id)
-        throw(API.H5Error("Type mismatch: requested type $T is not the stored type $stored_julia_type"))
+        throw(ArgumentError("Type mismatch: requested type $T is not the stored type $stored_julia_type"))
     end
 
     # Read data

--- a/test/test_type_stability.jl
+++ b/test/test_type_stability.jl
@@ -146,7 +146,7 @@ using JET
 
         # Test error cases
         # Trying to read a vector as a matrix should throw an error
-        @test_throws SimpleHDF5.API.H5Error SimpleHDF5.read_array(file_id, "vector", Matrix{Int})
+        @test_throws ArgumentError SimpleHDF5.read_array(file_id, "vector", Matrix{Int})
 
         # Close the file
         SimpleHDF5.close_file(file_id)


### PR DESCRIPTION
`API.H5Error` is really designed for errors thrown by the HDF5 JLL itself.

It also has a finalizer attached that `--trim` doesn't understand how to resolve yet.